### PR TITLE
Use colorama 0.4 which provides a workaround for PyCharm to get colorized output.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ zip_safe = True
 packages = find:
 
 install_requires =
-  colorama>=0.3.9,<0.4
+  colorama>=0.4.1,<0.5
   packaging>=17.1,<18
   requests>=2.18.4,<3
   termcolor>=1.1.0,<2


### PR DESCRIPTION
Hello,

Using more recent `colorama` allows it to make use of `PYCHARM_HOSTED` environment variable to get colorized output when running in PyCharm. A simple update from `0.3.9` to `0.4.1` works nicely.