### PR TITLE
add disable-fail argument

### DIFF
--- a/pip_outdated/__init__.py
+++ b/pip_outdated/__init__.py
@@ -11,7 +11,7 @@ def parse_args():
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Print verbose information.")
     parser.add_argument(
-        "-d", "--disable-fail", action="store_true",
+        "-q", "--quiet", action="store_true",
         help="Don't return exit code 1 if not everything is up to date.")
     parser.add_argument(
         "file", nargs="*", default=["requirements.txt", "setup.cfg"], metavar="<file>",
@@ -30,5 +30,5 @@ def main():
     from .print_outdated import print_outdated
     requires = find_require(args.file)
     outdated_results = check_outdated(requires)
-    print_outdated(outdated_results, args.disable_fail)
+    print_outdated(outdated_results, args.quiet)
     

--- a/pip_outdated/__init__.py
+++ b/pip_outdated/__init__.py
@@ -11,6 +11,9 @@ def parse_args():
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Print verbose information.")
     parser.add_argument(
+        "-d", "--disable-fail", action="store_true",
+        help="Don't return exit code 1 if not everything is up to date.")
+    parser.add_argument(
         "file", nargs="*", default=["requirements.txt", "setup.cfg"], metavar="<file>",
         help="Read dependencies from requirements files. This option accepts "
              "glob pattern.")
@@ -18,7 +21,7 @@ def parse_args():
 
 def main():
     args = parse_args()
-    
+
     from .verbose import set_verbose
     set_verbose(args.verbose)
     
@@ -27,5 +30,5 @@ def main():
     from .print_outdated import print_outdated
     requires = find_require(args.file)
     outdated_results = check_outdated(requires)
-    print_outdated(outdated_results)
+    print_outdated(outdated_results, args.disable_fail)
     

--- a/pip_outdated/print_outdated.py
+++ b/pip_outdated/print_outdated.py
@@ -33,7 +33,7 @@ def make_row(outdate):
         colored_latest()
     ]
 
-def print_outdated(outdates, disable_failure_exit: bool):
+def print_outdated(outdates, quiet: bool):
     colorama.init()
     
     data = [["Name", "Installed", "Wanted", "Latest"]]
@@ -55,6 +55,6 @@ def print_outdated(outdates, disable_failure_exit: bool):
     print(colored("Green = updatable", "green", attrs=["bold"]))
     table = Table(data)
     print(table.table)
-    if not disable_failure_exit:
+    if not quiet:
         sys.exit(1)
     

--- a/pip_outdated/print_outdated.py
+++ b/pip_outdated/print_outdated.py
@@ -33,7 +33,7 @@ def make_row(outdate):
         colored_latest()
     ]
 
-def print_outdated(outdates):
+def print_outdated(outdates, disable_failure_exit: bool):
     colorama.init()
     
     data = [["Name", "Installed", "Wanted", "Latest"]]
@@ -55,5 +55,6 @@ def print_outdated(outdates):
     print(colored("Green = updatable", "green", attrs=["bold"]))
     table = Table(data)
     print(table.table)
-    sys.exit(1)
+    if not disable_failure_exit:
+        sys.exit(1)
     


### PR DESCRIPTION
In order to allow adding this to ci in a non-blocking fashion: add an argument which prevents exiting with the failure exit code, regardless of there being package updates or not.