### PR TITLE
add release dates as output option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.7"
+  - "3.8"
 script:
   - pip install -e .
   - python cute.py test

--- a/pip_outdated/__init__.py
+++ b/pip_outdated/__init__.py
@@ -15,11 +15,14 @@ def parse_args():
         "-q", "--quiet", action="store_true",
         help="Don't return exit code 1 if not everything is up to date.")
     parser.add_argument(
+        "-d", "--dates", action="store_true",
+        help="Show date info for packages.")
+    parser.add_argument(
         "file", nargs="*", default=["requirements.txt", "setup.cfg"], metavar="<file>",
         help="Read dependencies from requirements files. This option accepts "
              "glob pattern.")
     return parser.parse_args()
-    
+
 def main():
     # FIXME: we can't use asyncio.run since it closes the event loop
     # https://github.com/aio-libs/aiohttp/issues/1925
@@ -32,13 +35,13 @@ async def _main():
 
     from .verbose import set_verbose
     set_verbose(args.verbose)
-    
+
     from .find_require import find_require
     from .check_outdated import check_outdated
     from .print_outdated import print_outdated
     from .session import get_session
-    
+
     requires = find_require(args.file)
     async with get_session() as session:
         outdated_results = [asyncio.create_task(check_outdated(r, session)) for r in requires]
-        await print_outdated(outdated_results, args.quiet)
+        await print_outdated(outdated_results, args.quiet, args.dates)

--- a/pip_outdated/check_outdated.py
+++ b/pip_outdated/check_outdated.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, TypedDict
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
@@ -9,24 +9,33 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 from .verbose import verbose
 
+class Release(TypedDict):
+    version: Version
+    date: str
 
 @dataclass
 class OutdateResult:
     requirement: Requirement
     version: Optional[Version]
-    all_versions: List[Version]
+    all_releases: List[Release]
 
-    wanted: Optional[Version] = None
-    latest: Optional[Version] = None
+    wanted_version: Optional[Version] = None
+    wanted_date: Optional[str] = None
+    latest_version: Optional[Version] = None
+    latest_date: Optional[str] = None
 
     def __post_init__(self):
-        if self.all_versions:
+        if self.all_releases:
             try:
-                self.wanted = next(v for v in reversed(self.all_versions)
-                                   if v in self.requirement.specifier)
+                wanted = next(r for r in reversed(self.all_releases)
+                              if r['version'] in self.requirement.specifier)
+                self.wanted_version = wanted['version']
+                self.wanted_date = wanted['date']
             except StopIteration:
                 pass
-            self.latest = self.all_versions[-1]
+            latest = self.all_releases[-1]
+            self.latest_version = latest['version']
+            self.latest_date = latest['date']
 
     @property
     def name(self) -> str:
@@ -34,35 +43,45 @@ class OutdateResult:
 
     def install_not_found(self) -> bool:
         return self.version is None
-        
+
     def install_not_wanted(self) -> bool:
         return self.version not in self.requirement.specifier
-        
+
     def pypi_not_found(self) -> bool:
-        return self.latest is None
-        
+        return self.latest_version is None
+
     def outdated(self) -> bool:
-        return self.version != self.wanted or self.version != self.latest
+        return (
+            self.version != self.wanted_version or
+            self.version != self.latest_version
+        )
 
 def get_current_version(name: str) -> Optional[Version]:
     try:
         return parse_version(get_distribution(name).version)
     except DistributionNotFound:
         pass
-        
-async def get_pypi_versions(name: str, session) -> List[Version]:
+
+async def get_pypi_releases(name: str, session) -> List[Version]:
     async with session.get(f"https://pypi.org/pypi/{name}/json") as r:
         if r.status != 200:
             return None
-        keys = [parse_version(v) for v in (await r.json())["releases"].keys()]
-        keys = [v for v in keys if not v.is_prerelease]
-        keys.sort()
-        return keys
-    
+        releases = []
+        for v, info in (await r.json())["releases"].items():
+            version = parse_version(v)
+            if version.is_prerelease or len(info) == 0:
+                continue
+            releases.append({
+                'version': version,
+                'date': info[0]['upload_time'][:10]
+            })
+        releases.sort(key=lambda release: release.get("version"))
+        return releases
+
 async def check_outdated(require, session) -> OutdateResult:
     if verbose():
         print(f"Checking: {require.name} {require.specifier}")
     name = canonicalize_name(require.name)
     current_version = get_current_version(name)
-    pypi_versions = await get_pypi_versions(name, session)
-    return OutdateResult(require, current_version, pypi_versions)
+    pypi_releases = await get_pypi_releases(name, session)
+    return OutdateResult(require, current_version, pypi_releases)

--- a/pip_outdated/print_outdated.py
+++ b/pip_outdated/print_outdated.py
@@ -9,54 +9,71 @@ from terminaltables import AsciiTable as Table
 from .check_outdated import OutdateResult
 
 
-def make_row(outdate: OutdateResult) -> Optional[List[str]]:
+def make_row(outdate: OutdateResult, dates: bool) -> Optional[List[str]]:
     if not outdate.outdated():
         return None
-        
+
     def colored_current():
         if outdate.install_not_found() or outdate.install_not_wanted():
             return colored(str(outdate.version), "red", attrs=["bold"])
         return str(outdate.version)
-        
-    def colored_wanted():
-        if outdate.pypi_not_found() or not outdate.wanted:
+
+    def colored_wanted_version():
+        if outdate.pypi_not_found() or not outdate.wanted_version:
             return colored("None", "red", attrs=["bold"])
-        if not outdate.install_not_found() and outdate.version < outdate.wanted:
-            return colored(str(outdate.wanted), "green", attrs=["bold"])
-        return str(outdate.wanted)
-        
-    def colored_latest():
+        if not outdate.install_not_found() and outdate.version < outdate.wanted_version:
+            return colored(str(outdate.wanted_version), "green", attrs=["bold"])
+        return str(outdate.wanted_version)
+
+    def colored_latest_version():
         if outdate.pypi_not_found():
             return colored("None", "red", attrs=["bold"])
-        if not outdate.install_not_found() and outdate.version < outdate.latest:
-            return colored(str(outdate.latest), "green", attrs=["bold"])
-        return str(outdate.latest)
-    
-    return [
-        outdate.name,
-        colored_current(),
-        colored_wanted(),
-        colored_latest()
-    ]
+        if not outdate.install_not_found() and outdate.version < outdate.latest_version:
+            return colored(str(outdate.latest_version), "green", attrs=["bold"])
+        return str(outdate.latest_version)
 
-async def print_outdated(outdates: List[Awaitable[OutdateResult]], quiet: bool):
+    if dates:
+        row = [
+            outdate.name,
+            colored_current(),
+            colored_wanted_version(),
+            outdate.wanted_date,
+            colored_latest_version(),
+            outdate.latest_date
+        ]
+    else:
+        row = [
+            outdate.name,
+            colored_current(),
+            colored_wanted_version(),
+            colored_latest_version()
+        ]
+    return row
+
+async def print_outdated(
+        outdates: List[Awaitable[OutdateResult]],
+        quiet: bool,
+        dates: bool
+    ):
     colorama.init()
-    
-    data = [["Name", "Installed", "Wanted", "Latest"]]
+    if dates:
+        data = [["Name", "Installed", "Wanted", "", "Latest", ""]]
+    else:
+        data = [["Name", "Installed", "Wanted", "Latest"]]
     count = 0
     for count, outdate in enumerate(outdates, 1):
-        row = make_row(await outdate)
+        row = make_row(await outdate, dates)
         if row:
             data.append(row)
-            
+
     if not count:
         print(colored("No requirements found.", "red"))
         return
-        
+
     if len(data) == 1:
         print(colored("Everything is up-to-date!", "cyan", attrs=["bold"]))
         return
-        
+
     print(colored("Red = unavailable/outdated/out of version specifier", "red", attrs=["bold"]))
     print(colored("Green = updatable", "green", attrs=["bold"]))
     table = Table(data)


### PR DESCRIPTION
Hey,
I am sometimes in a situation where I have a huge list of requirements and it's not enough to check whether there are never versions of my packages but also if the package has been released (uploaded to pypi) a long time ago. So I added the option to call it with `-d` for "dates" and the output then shows two additional columns with the dates for when the required version and the latest version were released.

Please let me know if you want me to make adjustments to fit better with your overall project structure.